### PR TITLE
add plugin board instance management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,10 +163,13 @@ config/custom_logos.json
 
 nhl-api-client/
 
-
-
 .codegpt
 
-# Local developer plugins (ignored)
-src/boards/plugins/
-*.ori
+# Ignore all plugin content
+/src/boards/plugins/**
+
+# But keep the empty folder so the path exists
+!/src/boards/plugins/.gitkeep
+
+# Allow a local .gitignore to live here too
+!/src/boards/plugins/.gitignore

--- a/src/boards/boards.py
+++ b/src/boards/boards.py
@@ -168,8 +168,12 @@ class Boards:
             Cached board instance
         """
         if board_name not in self._board_instances:
-            self._board_instances[board_name] = board_class(data, matrix, sleepEvent)
-            debug.info(f"Created new instance for legacy board: {board_name}")
+            try:
+                self._board_instances[board_name] = board_class(data, matrix, sleepEvent)
+                debug.info(f"Created new instance for legacy board: {board_name}")
+            except Exception as exc:
+                debug.error(f"Failed to load board: {board_name}. Board doesnt exist or typo in config.")
+                return None
         return self._board_instances[board_name]
 
     def clear_board_cache(self, board_name: str = None):
@@ -225,7 +229,7 @@ class Boards:
     def _off_day(self, data, matrix, sleepEvent):
         bord_index = 0
         while True:
-            board = getattr(self, data.config.boards_off_day[bord_index])
+            board = getattr(self, data.config.boards_off_day[bord_index], None)
             data.curr_board = data.config.boards_off_day[bord_index]
 
             if data.pb_trigger:
@@ -265,7 +269,11 @@ class Boards:
                 else:
                     data.pb_trigger = False
 
-            board(data, matrix, sleepEvent)
+            if board:
+                board(data, matrix, sleepEvent)
+            else :
+                debug.error(f"Board not found: {data.config.boards_off_day[bord_index]}. Check board exists and config.json is correct")
+
 
             if bord_index >= (len(data.config.boards_off_day) - 1):
                 return
@@ -276,7 +284,7 @@ class Boards:
     def _scheduled(self, data, matrix, sleepEvent):
         bord_index = 0
         while True:
-            board = getattr(self, data.config.boards_scheduled[bord_index])
+            board = getattr(self, data.config.boards_scheduled[bord_index], None)
             data.curr_board = data.config.boards_scheduled[bord_index]
             if data.pb_trigger:
                 debug.info('PushButton triggered....will display ' + data.config.pushbutton_state_triggered1 + ' board ' + "Overriding scheduled -> " + data.config.boards_scheduled[bord_index])
@@ -316,7 +324,10 @@ class Boards:
                 else:
                     data.pb_trigger = False
 
-            board(data, matrix, sleepEvent)
+            if board:
+                board(data, matrix, sleepEvent)
+            else :
+                debug.error(f"Board not found: {data.config.boards_scheduled[bord_index]}. Check board exists and config.json is correct")
 
             if bord_index >= (len(data.config.boards_scheduled) - 1):
                 return
@@ -327,7 +338,7 @@ class Boards:
     def _intermission(self, data, matrix, sleepEvent):
         bord_index = 0
         while True:
-            board = getattr(self, data.config.boards_intermission[bord_index])
+            board = getattr(self, data.config.boards_intermission[bord_index], None)
             data.curr_board = data.config.boards_intermission[bord_index]
 
             if data.pb_trigger:
@@ -367,7 +378,11 @@ class Boards:
             #     else:
             #         data.pb_trigger = False
         
-            board(data, matrix, sleepEvent)
+            if board:
+                board(data, matrix, sleepEvent)
+            else :
+                debug.error(f"Board not found: {data.config.boards_intermission[bord_index]}. Check board exists and config.json is correct")
+
 
             if bord_index >= (len(data.config.boards_intermission) - 1):
                 return
@@ -378,7 +393,7 @@ class Boards:
     def _post_game(self, data, matrix, sleepEvent):
         bord_index = 0
         while True:
-            board = getattr(self, data.config.boards_post_game[bord_index])
+            board = getattr(self, data.config.boards_post_game[bord_index], None)
             data.curr_board = data.config.boards_post_game[bord_index]
 
             if data.pb_trigger:
@@ -419,7 +434,10 @@ class Boards:
                     data.pb_trigger = False
 
 
-            board(data, matrix, sleepEvent)
+            if board:
+                board(data, matrix, sleepEvent)
+            else :
+                debug.error(f"Board not found: {data.config.boards_post_game[bord_index]}. Check board exists and config.json is correct")
 
             if bord_index >= (len(data.config.boards_post_game) - 1):
                 return

--- a/src/boards/builtins/season_countdown/board.py
+++ b/src/boards/builtins/season_countdown/board.py
@@ -37,18 +37,24 @@ class SeasonCountdownBoard(BoardBase):
         self.font = data.config.layout.font
         self.font_large = data.config.layout.font_large
 
-        # Set up season text
+        # Set up season text (static parts only)
         self.season_start = datetime.strptime(self.data.status.next_season_start(), '%Y-%m-%d').date()
-        self.days_until_season = (self.season_start - date.today()).days
 
-        current_year = date.today().year
-        next_year = current_year + 1
-
-        self.nextseason="{0}-{1}".format(current_year,next_year)
-        self.nextseason_short="NHL {0}-{1}".format(str(current_year)[-2:],str(next_year)[-2:])
+        # Date-dependent values will be computed fresh in render()
+        self.days_until_season = None
+        self.nextseason = None
+        self.nextseason_short = None
     
     def render(self):
-        
+        # Compute fresh date-dependent values
+        today = date.today()
+        self.days_until_season = (self.season_start - today).days
+
+        current_year = today.year
+        next_year = current_year + 1
+        self.nextseason = "{0}-{1}".format(current_year, next_year)
+        self.nextseason_short = "NHL {0}-{1}".format(str(current_year)[-2:], str(next_year)[-2:])
+
         debug.info("NHL Countdown Launched")
 
         # for testing purposes

--- a/src/boards/clock.py
+++ b/src/boards/clock.py
@@ -18,7 +18,6 @@ class Clock:
     def __init__(self, data, matrix, sleepEvent ,duration=None):
 
         self.data = data
-        self.date = datetime.datetime.today()
         self.time = datetime.datetime.now()
 
         self.matrix = matrix
@@ -124,7 +123,7 @@ class Clock:
 
         self.matrix.draw_text_layout(
             self.layout.date,
-            self.date.strftime("%b %d %Y").upper(),
+            datetime.datetime.today().strftime("%b %d %Y").upper(),
             fillColor=self.wxdtfill
         )
 


### PR DESCRIPTION
boards used to instantiate on each loop. Now they are instantiated once, stored, and retrieved when they need to render. Also, added exception handling to catch and log if a board doesn't exist.  This will gracefully handle configs that reference missing boards or are spelled wrong.