### PR TITLE
Add early initialization for boards requiring data fetching

### DIFF
--- a/src/boards/base_board.py
+++ b/src/boards/base_board.py
@@ -47,15 +47,19 @@ class BoardLayoutConfig(LayoutConfig):
 class BoardBase(ABC):
     """
     Abstract base class for all board modules.
-    
+
     All board modules (plugins and builtins) must inherit from this class and implement the required methods.
     This ensures a consistent interface for the board loading system.
     """
+
+    # Class attribute: indicates whether this board type requires early initialization
+    # Set to True in subclasses that need to start data fetching before first render
+    requires_early_initialization = False
     
     def __init__(self, data, matrix: Matrix, sleepEvent):
         """
         Initialize the board module.
-        
+
         Args:
             data: Application data object containing config and state
             matrix: Display matrix object for rendering
@@ -64,15 +68,15 @@ class BoardBase(ABC):
         self.data = data
         self.matrix = matrix
         self.sleepEvent = sleepEvent
-        
+
         # Board metadata (should be overridden by subclasses)
         self.board_name = self.__class__.__name__
         self.board_version = "1.0.0"
         self.board_description = "A board module"
-        
+
         # Detect display size
         self.display_width, self.display_height = self._detect_display_size()
-        
+
         # Load board-specific config and layout
         self.board_config = self._load_board_config()
         self.board_layout = self._create_board_layout_config()
@@ -81,7 +85,7 @@ class BoardBase(ABC):
     def render(self):
         """
         Render the board content to the matrix.
-        
+
         This method must be implemented by all board modules.
         It should handle the complete display logic for the board.
         """
@@ -254,45 +258,3 @@ class BoardBase(ABC):
         """
         return self.board_layout is not None
 
-
-# class LegacyBoardAdapter(BoardBase):
-#     """
-#     Adapter class to wrap existing legacy boards.
-    
-#     This allows existing boards to work with the board loading system without modification.
-#     """
-    
-#     def __init__(self, data, matrix, sleepEvent, board_class, *args, **kwargs):
-#         """
-#         Initialize the legacy board adapter.
-        
-#         Args:
-#             data: Application data object
-#             matrix: Display matrix object  
-#             sleepEvent: Threading event
-#             board_class: The legacy board class to wrap
-#             *args, **kwargs: Additional arguments to pass to the legacy board
-#         """
-#         super().__init__(data, matrix, sleepEvent)
-        
-#         # Create instance of the legacy board
-#         self.board_instance = board_class(data, matrix, sleepEvent, *args, **kwargs)
-        
-#         # Set board metadata based on the legacy board
-#         self.board_name = board_class.__name__
-#         self.board_description = f"Legacy board: {board_class.__name__}"
-    
-#     def render(self):
-#         """
-#         Delegate rendering to the legacy board instance.
-        
-#         Handles different legacy board interfaces (render() method vs direct execution).
-#         """
-#         if hasattr(self.board_instance, 'render'):
-#             self.board_instance.render()
-#         elif hasattr(self.board_instance, 'draw'):
-#             self.board_instance.draw()
-#         else:
-#             # Some legacy boards execute in their constructor
-#             # In this case, the board has already been "rendered"
-#             pass

--- a/src/boards/boards.py
+++ b/src/boards/boards.py
@@ -207,6 +207,37 @@ class Boards:
         """
         return list(self._board_instances.keys())
 
+    def initialize_boards_with_data_requirements(self, data, matrix, sleepEvent):
+        """
+        Pre-initialize boards that require early data fetching.
+
+        This method checks board classes for requires_early_initialization = True and
+        only instantiates those boards, allowing them to start background data fetching
+        before the render loop begins.
+
+        Args:
+            data: Application data object
+            matrix: Display matrix object
+            sleepEvent: Threading event for sleep/wake control
+        """
+        debug.info("Boards: Pre-initializing boards with data requirements")
+        initialized_count = 0
+
+        for board_name, board_class in self._boards.items():
+            try:
+                # Check class attribute directly - no need to instantiate to check
+                if getattr(board_class, 'requires_early_initialization', False):
+                    # Only instantiate boards that actually need early initialization
+                    board_instance = board_class(data, matrix, sleepEvent)
+                    self._board_instances[board_name] = board_instance
+                    debug.info(f"Boards: Pre-initialized board '{board_name}' for early data fetching")
+                    initialized_count += 1
+
+            except Exception as exc:
+                debug.error(f"Boards: Failed to pre-initialize board '{board_name}': {exc}")
+
+        debug.info(f"Boards: Pre-initialized {initialized_count} boards with data requirements")
+
     # Board handler for PushButton
     def _pb_board(self, data, matrix, sleepEvent):
 

--- a/src/renderer/main.py
+++ b/src/renderer/main.py
@@ -26,6 +26,11 @@ class MainRenderer:
         self.sog_display_frequency = data.config.sog_display_frequency
         self.alternate_data_counter = 1
 
+        # Pre-initialize boards that require early data fetching
+        # This allows boards to start background data processes
+        # before the render loop begins, ensuring data is available on first render
+        self.boards.initialize_boards_with_data_requirements(data, matrix, sleepEvent)
+
     def render(self):
 
         if self.data.config.testing_mode:


### PR DESCRIPTION
- Introduced `requires_early_initialization` class attribute in `BoardBase` to indicate boards that need early data fetching.
- Implemented `initialize_boards_with_data_requirements` method in `Boards` class to pre-initialize these boards.
- Updated `MainRenderer` to call the new method, ensuring data is available before the render loop starts.