### PR TITLE
Also catch TypeError in refresh_overview

### DIFF
--- a/src/data/data.py
+++ b/src/data/data.py
@@ -435,7 +435,7 @@ class Data:
                 self.needs_refresh = False
                 self.network_issues = False
                 break
-            except ValueError as error_message:
+            except (ValueError, TypeError) as error_message:
                 self.network_issues = True
                 debug.error("Failed to refresh the Overview. {} attempt remaining.".format(attempts_remaining))
                 debug.error(error_message)


### PR DESCRIPTION
This happened a few time tonight:

```
│ /home/eric/code/nhl-led-scoreboard/src/data/data.py:432 in refresh_overview  │
│                                                                              │
│   429 │   │   │   try:                                                       │
│   430 │   │   │   │   self.overview = nhl_api.overview(self.current_game_id) │
│   431 │   │   │   │   # TODO: Not sure what was going on here                │
│ ❱ 432 │   │   │   │   if self.time_stamp != self.overview["clock"]["timeRema │
│   433 │   │   │   │   │   self.time_stamp = self.overview["clock"]["timeRema │
│   434 │   │   │   │   │   self.new_data = True                               │
│   435 │   │   │   │   self.needs_refresh = False                             │
│                                                                              │
│ ╭─────────────────────────── locals ───────────────────────────╮             │
│ │ attempts_remaining = 5                                       │             │
│ │               self = <data.data.Data object at 0x7f7318d2b0> │             │
│ ╰──────────────────────────────────────────────────────────────╯             │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: 'NoneType' object is not subscriptable
```

So let's also catch TypeError and retry just like with ValueError