### PR TITLE
Update font for title in 128x64 layout config

### DIFF
--- a/config/layout/layout_128x64.json
+++ b/config/layout/layout_128x64.json
@@ -769,7 +769,7 @@
     "title": {
       "position": [124, 2],
       "align": "right-top",
-      "font": "wx_small"
+      "font": "small_2"
     },
     "name": {
       "position": [125, 10],


### PR DESCRIPTION
Changed the font for the 'title' field from 'wx_small' to 'small_2' in layout_128x64.json to ensure consistency or improved appearance.