### PR TITLE
Add cache cleanup and permission fix to plugin manager

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -20,6 +20,9 @@ python plugins.py add https://github.com/kas21/nls-plugin-nfl_board.git
 # Remove a plugin but keep your configuration
 python plugins.py rm nfl_board --keep-config
 
+# Clean up cache files and fix permissions (usually automatic)
+python plugins.py cleanup
+
 # Enable verbose logging for troubleshooting
 python plugins.py --verbose sync
 ```
@@ -122,6 +125,29 @@ python plugins.py rm nfl_board
 - Removes the plugin from `plugins.json`
 - Deletes the plugin directory
 - If `--keep-config` is used: Preserves your configuration files in the plugin directory
+
+### `cleanup` - Clean Cache and Fix Permissions
+
+Clean up Python cache files and fix root-owned file permissions. **This runs automatically before `add` and `sync` commands**, so you typically don't need to run it manually.
+
+```bash
+# Manual cleanup (rarely needed)
+python plugins.py cleanup
+```
+
+**What it does:**
+
+- Removes `__pycache__` directories (including root-owned ones)
+- Cleans up `/tmp/sb_cache` if owned by root
+- Fixes ownership of root-owned files to your user account
+
+**When to use manually:**
+
+- If plugin updates are failing due to permission errors
+- After running the scoreboard with `sudo` and encountering file permission issues
+- When troubleshooting plugin installation problems
+
+> **Note:** This functionality replaces the need to run `scripts/sbtools/sb-cleanup-cache` separately. The plugin manager now handles cache cleanup automatically!
 
 ## User File Preservation
 
@@ -274,15 +300,26 @@ sudo systemctl restart nhl-scoreboard
 
 If `python plugins.py sync` fails to update a plugin:
 
-1. **Check your internet connection**
-2. **Try with verbose logging to see detailed errors:**
+1. **Try cleaning cache and permissions first:**
+
+   ```bash
+   python plugins.py cleanup
+   python plugins.py sync
+   ```
+
+   The plugin manager runs cleanup automatically, but running it manually with verbose output can help diagnose issues.
+
+2. **Check your internet connection**
+
+3. **Try with verbose logging to see detailed errors:**
 
    ```bash
    python plugins.py --verbose sync
    ```
 
-3. **Verify the git repository URL is correct** in `plugins.json`
-4. **Check if the repository is accessible** (try opening the GitHub URL in a browser)
+4. **Verify the git repository URL is correct** in `plugins.json`
+
+5. **Check if the repository is accessible** (try opening the GitHub URL in a browser)
 
 The plugin manager automatically restores the previous version if an update fails, so your installation is safe.
 

--- a/src/boards/plugins/example_board/README.md
+++ b/src/boards/plugins/example_board/README.md
@@ -112,9 +112,7 @@ __Example:__
     "python_dependencies": []
   },
 
-  "preserve_files": [
-    "config.json"
-  ]
+  "preserve_files": []
 }
 ```
 
@@ -129,7 +127,7 @@ __Example:__
 | `enabled` | Boolean | No | Whether plugin is enabled (default: true). Set to false to disable without uninstalling. |
 | `boards` | Array | Yes | List of board classes this plugin provides (see below). |
 | `requirements` | Object | No | Version and dependency requirements (see below). |
-| `preserve_files` | Array | No | Files to preserve during updates/removal (default: config.json, *.csv, data/*, custom_*). |
+| `preserve_files` | Array | No | Additional files to preserve during updates/removal. Always includes defaults: config.json, *.csv, data/*, custom_*. |
 
 #### boards Array
 
@@ -420,9 +418,7 @@ cd my_custom_board
     "python_dependencies": []
   },
 
-  "preserve_files": [
-    "config.json"
-  ]
+  "preserve_files": []
 }
 ```
 
@@ -522,18 +518,26 @@ Specify minimum versions if you use newer features:
 
 ### File Preservation
 
-Specify files to preserve during updates:
+Specify __additional__ files to preserve during updates. The plugin manager always preserves these default patterns:
+
+- `config.json` - Plugin configuration
+- `*.csv` - CSV data files
+- `data/*` - All files in data directory
+- `custom_*` - Custom user files
+
+Add plugin-specific patterns to preserve additional files:
 
 ```json
 {
   "preserve_files": [
-    "config.json",
-    "custom_data.csv",
-    "data/*.json",
-    "user_*"
+    "*.db",           // Database files
+    "cache/*.json",   // Cached data
+    "user_settings/*" // User settings directory
   ]
 }
 ```
+
+__Note:__ You don't need to include the default patterns - they're always preserved automatically. Only specify additional files unique to your plugin.
 
 Supports glob patterns for flexible matching.
 

--- a/src/boards/plugins/example_board/plugin.json
+++ b/src/boards/plugins/example_board/plugin.json
@@ -18,7 +18,5 @@
     "python_dependencies": []
   },
 
-  "preserve_files": [
-    "config.json"
-  ]
+  "preserve_files": []
 }


### PR DESCRIPTION
Introduces a 'cleanup' command to plugins.py that removes Python cache files and fixes root-owned file permissions, running automatically before add and sync operations. Updates documentation to reflect new cleanup behavior and clarifies file preservation defaults and usage in example_board plugin and docs.

- Removes Python cache files (__pycache__) that can interfere with git operations
- Fixes root-owned file permissions from previous sudo runs
- Runs automatically before add and sync operations
- Can be manually triggered with python plugins.py cleanup