### PR TITLE
Fix MQTT authentication path in scoreboard configuration

### DIFF
--- a/src/data/scoreboard_config.py
+++ b/src/data/scoreboard_config.py
@@ -72,8 +72,8 @@ class ScoreboardConfig:
                 self.mqtt_main_topic = "scoreboard"
 
             try:
-                self.mqtt_username = json["mqtt"]["auth"]["username"]
-                self.mqtt_password = json["mqtt"]["auth"]["password"]
+                self.mqtt_username = json["sbio"]["mqtt"]["auth"]["username"]
+                self.mqtt_password = json["sbio"]["mqtt"]["auth"]["password"]
             except KeyError:
                 pass
 


### PR DESCRIPTION
The configuration parsing code was looking for the MQTT broker username and password at the wrong location in `config.json`. This prevented the app from sending messages to non-anonymous brokers.