### PR TITLE
Improve MQTT Board State Granularity for Home Assistant Integration

### DIFF
--- a/src/renderer/main.py
+++ b/src/renderer/main.py
@@ -190,11 +190,6 @@ class MainRenderer:
                 self.__render_live(sbrenderer)
                 if self.scoreboard.intermission:
                     debug.info("Main event is in Intermission")
-                    if self.data.config.mqtt_enabled:
-                        # Add game state onto queue
-                        qPayload = "intermission"
-                        qItem = ["{0}/state".format(self.data.config.mqtt_main_topic),qPayload]
-                        self.sbQueue.put_nowait(qItem)  
 
                     # Show Boards for Intermission
                     self.draw_end_period_indicator()


### PR DESCRIPTION
This change refines how board state is published over MQTT by introducing finer-grained state transitions during a game. The primary motivation is to enable more expressive and reliable automations in Home Assistant that depend on accurate game phase information.

Previously, the board exposed a very coarse state model, collapsing all in-game activity into a single “intermission” bucket between pregame and postgame:

`---pregame--------------|---intermission--------------------------------------------|---postgame---`


With this change, the board now explicitly signals when the game is live versus between periods, resulting in the following timeline:

`---pregame---|---live---|---intermission---|---live---|---intermission---|---live---|---postgame---`


Publishing distinct live and intermission states allows Home Assistant to react appropriately to each phase (e.g., driving animations, lighting behavior, or notifications only while play is active), rather than inferring intent from a single overloaded state. This improves both the accuracy and flexibility of downstream consumers without changing the overall lifecycle of a game.
