### PR TITLE
Eliminated else block that set self.scroll to False

### DIFF
--- a/src/boards/wxAlert.py
+++ b/src/boards/wxAlert.py
@@ -25,8 +25,6 @@ class wxAlert:
 
         if self.sleepEvent.is_set():
             self.sleepEvent.clear()
-        else:
-            self.scroll = False
 
         self.wxfont = data.config.layout.wxalert_font
 


### PR DESCRIPTION
this was overriding the preference in the config and causing the alert board to always scroll