### PR TITLE
20252026 seriesticker board fix

### DIFF
--- a/src/boards/seriesticker.py
+++ b/src/boards/seriesticker.py
@@ -9,6 +9,7 @@ from PIL import Image
 from data.data import Data
 
 # from data.playoffs import Series
+from nhl_api.client import NHLAPIError
 from data.scoreboard import Scoreboard
 from nhl_api.data import get_game
 from renderer.matrix import Matrix, MatrixPixels
@@ -86,7 +87,7 @@ class Seriesticker:
         if self.data.config.seriesticker_hide_completed_rounds:
             playoff_series = [
                 s for s in self.data.series
-                if getattr(s, "round_number", 0) >= self.data.current_round["roundNumber"]
+                if getattr(s, 'round_number', 0) >= self.data.current_round.get('roundNumber', 1)
             ]
 
         self.num_series = len(playoff_series)
@@ -308,6 +309,16 @@ class Seriesticker:
                     )
                     debug.error(error_message)
                     break
+                except NHLAPIError as error_message:
+                    # 404 means this game was never played (e.g. an if-necessary game
+                    # in a series that ended early). Stop processing — subsequent games
+                    # in the series will also be unplayed.
+                    debug.warning(
+                        "Game {} not found (unplayed if-necessary game). "
+                        "Skipping remaining games in series.".format(game["id"])
+                    )
+                    debug.error(error_message)
+                    return
             # If one of the request for player info failed after 5 attempts, return an empty dictionary
             if attempts_remaining == 0:
                 return False

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -581,81 +581,76 @@ class Data:
 
     #
     # Playoffs
+    """
+        Currently the series ticker request all the games of a series everytime its asked to load on screen.
+        This create a lot of delay between showing each series.
+        TODO:
+            Add a refresh function to the Series object instead and trigger a refresh
+            only at specific time in the renderer.(End of a game, new day)
+    """
     def refresh_playoff(self):
-        """
-            Currently the series ticker request all the games of a series everytime its asked to load on screen.
-            This create a lot of delay between showing each series.
-            TODO:
-                Add a refresh function to the Series object instead and trigger a refresh
-                only at specific time in the renderer.(End of a game, new day)
-        """
         self.current_round = None
         self.current_round_name = None
-        self.stanleycup_round = None
+        self.stanleycup_round = False
+        self.series = []
+
         attempts_remaining = 5
         while attempts_remaining > 0:
             try:
-                # Get the plaoffs data from the nhl api
-                self.playoffs = nhl_info.Playoff(nhl_info.playoff_info(self.status.season_id))
-                # Check if there is any rounds avaialable and grab the most recent one available.
-                if self.playoffs.rounds:
-                    self.current_round = self.playoffs.rounds[str(self.playoffs.default_round)]
-                    self.current_round_name = self.current_round["roundLabel"]
-                    if self.current_round_name == "Stanley Cup Qualifier":
-                        self.current_round_name = "Qualifier"
-                    if self.playoffs.default_round == 4:
-                        self.stanleycup_round = True
+                from nhl_api.nhl_client import client
+                year = str(self.status.season_id)[:4]
+                int(year)  # validate
+                bracket = client._request(f"https://api-web.nhle.com/v1/playoff-bracket/{int(year)+1}")
 
-                    debug.debug("defaultround number is : {}".format(self.playoffs.default_round))
-                    #8478996
+                all_series = bracket.get("series", [])
+
+                # Filter to only series that have teams assigned (active rounds)
+                active_series = [s for s in all_series if "topSeedTeam" in s and "bottomSeedTeam" in s]
+
+                if not active_series:
+                    debug.info("No active playoff series found")
+                    self.isPlayoff = False
+                    break
+
+                # Find the highest active round
+                max_round = max(s["playoffRound"] for s in active_series)
+                self.current_round = {"roundNumber": max_round}
+                self.current_round_name = active_series[-1].get("seriesTitle", "Playoffs")
+                self.stanleycup_round = max_round >= 4
+
+                # Build Series objects from all active series
+                for s in active_series:
                     try:
-                        self.series = []
+                        series_obj = Series(s, self)
+                        if hasattr(series_obj, 'top_team'):
+                            self.series.append(series_obj)
+                    except Exception as e:
+                        debug.error(f"Failed to build Series for {s.get('seriesLetter')}: {e}")
 
-                        # Grab the series of the current round of playoff.
-                        self.series_list = self.current_round["series"]
+                if not self.series:
+                    self.isPlayoff = False
+                    break
 
-                        self.series_list = []
-                        for i in self.playoffs.rounds:
-                            for j in self.playoffs.rounds[i]["series"]:
-                                self.series_list.append(j)
+                # Hide lower-round series if teams have advanced
+                highest_round = max(s.round_number for s in self.series)
+                advanced_teams = set()
+                for s in self.series:
+                    if s.round_number == highest_round:
+                        advanced_teams.add(s.top_team.abbrev)
+                        advanced_teams.add(s.bottom_team.abbrev)
+                for s in self.series:
+                    if s.round_number < highest_round:
+                        if s.top_team.abbrev in advanced_teams or s.bottom_team.abbrev in advanced_teams:
+                            s.show = False
 
-                        # Check if prefered team are part of the current round of playoff
-                        self.pref_series = self.series_list
+                self.isPlayoff = True
+                self.network_issues = False
 
-                        # If the user as set to show his favorite teams in the seriesticker
-                        if self.config.seriesticker_preferred_teams_only and self.pref_series:
-                            self.series_list = self.pref_series
-                        for s in self.series_list:
-                            self.series.append(Series(s,self))
-
-                        highest_round = self.series[-1].round_number
-                        teams = []
-                        for s in self.series[::-1]:
-                            if s.round_number == highest_round:
-                                teams.append(s.top_team.abbrev)
-                                teams.append(s.bottom_team.abbrev)
-
-                            if int(s.round_number) < int(highest_round):
-                                team1 = s.top_team.abbrev
-                                team2 = s.bottom_team.abbrev
-
-                                if((team1 in teams) or (team2 in teams)):
-                                    s.show = False
-
-
-                        self.isPlayoff = True
-                    except AttributeError:
-                        debug.error(
-                            "The {} Season playoff has not started or is unavailable".format(self.playoffs.season)
-                        )
-
-                        self.isPlayoff = False
-                        break
                 break
 
             except ValueError as error_message:
                 self.network_issues = True
-                debug.error("Failed to refresh the list of Series. {} attempt remaining.".format(attempts_remaining))
+                debug.error(f"Failed to refresh playoff data. {attempts_remaining} attempts remaining.")
                 debug.error(error_message)
                 attempts_remaining -= 1
                 sleep(NETWORK_RETRY_SLEEP_TIME)

--- a/src/data/data.py
+++ b/src/data/data.py
@@ -606,7 +606,8 @@ class Data:
 
                 # Filter to only series that have teams assigned (active rounds)
                 active_series = [s for s in all_series if "topSeedTeam" in s and "bottomSeedTeam" in s]
-
+                self.pref_series = active_series
+                
                 if not active_series:
                     debug.info("No active playoff series found")
                     self.isPlayoff = False
@@ -617,6 +618,17 @@ class Data:
                 self.current_round = {"roundNumber": max_round}
                 self.current_round_name = active_series[-1].get("seriesTitle", "Playoffs")
                 self.stanleycup_round = max_round >= 4
+
+                # Build Series objects from all active series
+                # Filter to preferred teams if configured
+                if self.config.seriesticker_preferred_teams_only and self.pref_series:
+                    pref_abbrevs = {t.get("abbrev") for t in self.pref_series if "abbrev" in t}
+                    active_series = [
+                        s for s in active_series
+                        if s.get("topSeedTeam", {}).get("abbrev") in pref_abbrevs
+                        or s.get("bottomSeedTeam", {}).get("abbrev") in pref_abbrevs
+                    ]
+
 
                 # Build Series objects from all active series
                 for s in active_series:

--- a/src/data/playoffs.py
+++ b/src/data/playoffs.py
@@ -38,8 +38,8 @@ class Series:
             This is off from the nhl record api. Not sure if it will update as soon as the day is over.
         """
         try:
-            series_info = client.get_series_record(series["seriesLetter"], data.status.season_id)
-            if series_info["total"] == 0:
+              series_info = client._request(f"https://api-web.nhle.com/v1/schedule/playoff-series/{data.status.season_id}/{series['seriesLetter'].lower()}"); series_info["topSeed"], series_info["bottomSeed"], series_info["total"] = series_info["topSeedTeam"], series_info["bottomSeedTeam"], len(series_info.get("games", []))
+              if series_info["total"] == 0:
                 debug.info("No series, playoffs not running?")
                 raise Exception("No series information")
         except Exception:
@@ -56,8 +56,8 @@ class Series:
         except Exception:
             self.conference = ""
         self.series_letter = series["seriesLetter"]
-        self.round_number = series["roundNumber"]
-        self.round_name = series["seriesLabel"]
+        self.round_number = series["playoffRound"]
+        self.round_name = series["seriesTitle"]
         self.top_team = SeriesTeam(top, top_team_abbrev)
         self.bottom_team = SeriesTeam(bottom, bottom_team_abbrev)
         self.games = series_info["games"]

--- a/src/data/team.py
+++ b/src/data/team.py
@@ -26,8 +26,9 @@ class TeamScore(Team):
 
 class SeriesTeam(Team):
     def __init__(self, matchupTeam, abbrev):
-        super().__init__(matchupTeam["id"], abbrev, matchupTeam["name"]["default"])
-        self.isTop = matchupTeam["seed"]
-        self.rank = matchupTeam["seed"]
-        self.series_wins = matchupTeam["seriesWins"]
-        self.series_losses = matchupTeam["record"].split("-")[1]
+        super().__init__(matchupTeam['id'], abbrev, matchupTeam['name']['default'])
+        self.isTop = matchupTeam.get('seed', 0) == 1
+        self.rank = matchupTeam.get('seed', 0)
+        self.series_wins = matchupTeam.get('seriesWins', 0)
+        record = matchupTeam.get('record', '0-0')
+        self.series_losses = int(record.split('-')[1])


### PR DESCRIPTION
Fixes seriesticker to use 2025/2026 NHL playoffs data structure. AI driven fix, but I've been running it since the start with only the series finishing crash so far. Not 100% sure how round 2 will affect this.

Implements a new error fallback when a series has ended. Previously would fall through if a series ended before 7 games. Biggest retwrite is around the refresh_playoffs call.